### PR TITLE
docs: fix tool/prompt counts and documentation discrepancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Tengu uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.3.0] — Social Engineering
+
+### Added
+
+**Social Engineering Tools (3 new MCP tools)**
+- `set_credential_harvester` — clone a website and capture credentials via SET (authorized phishing simulations only; requires explicit human confirmation)
+- `set_qrcode_attack` — generate a QR code pointing to a target URL for physical social engineering assessments
+- `set_payload_generator` — generate social engineering payloads (PowerShell alphanumeric, reverse, HTA) for authorized red team engagements; requires explicit human confirmation
+
+**Prompts (2 new MCP prompts)**
+- `social_engineering_assessment` — structured social engineering assessment workflow covering phishing, pretexting, and physical access
+- `msf_exploit_workflow` — step-by-step Metasploit module selection, configuration, and execution workflow
+
+---
+
 ## [0.2.1] — Quality and Stealth
 
 ### Added
@@ -18,7 +33,7 @@ Tengu uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `proxy_check` — verify proxy reachability and detect IP leak conditions
 - `rotate_identity` — rotate proxy/user-agent and request a new Tor identity atomically
 
-**Quick Action Prompts (8 new prompts in `src/tengu/prompts/quick_actions.py`)**
+**Quick Action Prompts (9 new prompts in `src/tengu/prompts/quick_actions.py`)**
 - `crack_wifi` — guided Wi-Fi capture and offline WPA/WPA2 crack workflow
 - `explore_url` — rapid single-URL web assessment
 - `go_stealth` — configure and verify stealth posture before an engagement
@@ -27,6 +42,7 @@ Tengu uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `hunt_subdomains` — passive and active subdomain enumeration workflow
 - `find_vulns` — template-based vulnerability sweep across a target
 - `pwn_target` — full exploitation workflow with post-exploitation checklist
+- `msf_exploit_workflow` — step-by-step Metasploit module selection, configuration, and execution workflow
 
 ### Improved
 
@@ -271,6 +287,7 @@ abstraction layer over industry-standard pentesting tools.
 
 ---
 
-[0.2.1]: https://github.com/tengu-project/tengu/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/tengu-project/tengu/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/tengu-project/tengu/releases/tag/v0.1.0
+[0.3.0]: https://github.com/rfunix/tengu/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/rfunix/tengu/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/rfunix/tengu/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/rfunix/tengu/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ pentesting tools to AI assistants through a clean, secure interface.
 | Entry point     | `src/tengu/server.py` → `FastMCP("Tengu")`        |
 | Config file     | `tengu.toml` at project root                      |
 | Test suite      | 1931+ tests, 0 lint errors |
-| Tools           | 66 MCP tools                                      |
+| Tools           | 63 MCP tools                                      |
 | Resources       | 20 MCP resources                                  |
-| Prompts         | 35 MCP prompts                                    |
+| Prompts         | 34 MCP prompts                                    |
 
 ---
 
@@ -145,12 +145,17 @@ src/tengu/
     ├── vuln_assessment.py  # assess_injection, assess_access_control, assess_crypto, assess_misconfig
     ├── report_prompts.py   # executive_report, technical_report, full_pentest_report,
     │                       # remediation_plan, finding_detail, risk_matrix, retest_report
-    ├── advanced_workflows.py # osint_investigation, stealth_assessment, opsec_checklist,
-    │                         # api_security_assessment, ad_assessment, container_assessment,
-    │                         # cloud_assessment, bug_bounty_workflow, compliance_assessment,
-    │                         # wireless_assessment
+    ├── osint_workflow.py   # osint_investigation
+    ├── stealth_prompts.py  # stealth_assessment, opsec_checklist
+    ├── api_assessment.py   # api_security_assessment
+    ├── ad_assessment.py    # ad_assessment
+    ├── container_assessment.py # container_assessment
+    ├── bug_bounty.py       # bug_bounty_workflow
+    ├── compliance_assessment.py # compliance_assessment
+    ├── wireless_assessment.py   # wireless_assessment
     ├── quick_actions.py    # crack_wifi, explore_url, go_stealth, find_secrets,
-    │                       # map_network, hunt_subdomains, find_vulns, pwn_target
+    │                       # map_network, hunt_subdomains, find_vulns, pwn_target,
+    │                       # msf_exploit_workflow
     └── social_engineering.py # social_engineering_assessment
 ```
 
@@ -170,7 +175,9 @@ enabled = true
 
 [stealth.proxy]
 enabled = true
-url = "socks5h://127.0.0.1:9050"   # Tor SOCKS5 proxy
+type = "socks5h"
+host = "127.0.0.1"
+port = 9050
 ```
 
 ### What the Stealth Layer Does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,9 @@ src/tengu/
 ├── security/              # sanitizer, allowlist, rate_limiter, audit logger
 ├── executor/              # Safe async subprocess runner (never shell=True)
 ├── stealth/               # Tor/proxy injection, UA rotation, timing jitter
-├── tools/                 # 66 MCP tools, grouped by category
+├── tools/                 # 63 MCP tools, grouped by category
 ├── resources/             # 20 MCP resources (static JSON + loader functions)
-└── prompts/               # 35 MCP workflow prompts
+└── prompts/               # 34 MCP workflow prompts
 ```
 
 Every tool invocation passes through this mandatory pipeline:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-green.svg" alt="MCP"></a>
-  <img src="https://img.shields.io/badge/tools-66-orange.svg" alt="Tools">
+  <img src="https://img.shields.io/badge/tools-63-orange.svg" alt="Tools">
   <img src="https://img.shields.io/badge/version-0.2.1-brightgreen.svg" alt="Version">
   <img src="https://img.shields.io/badge/agent-LangGraph-purple.svg" alt="Agent">
 </p>
 
 ---
 
-**Tengu** is an MCP server that turns Claude into a penetration testing copilot. It orchestrates 66 security tools — from Nmap to Metasploit — with built-in safety controls, audit logging, and professional reporting.
+**Tengu** is an MCP server that turns Claude into a penetration testing copilot. It orchestrates 63 security tools — from Nmap to Metasploit — with built-in safety controls, audit logging, and professional reporting.
 
 - **What is it?** An MCP server that connects Claude to industry-standard pentest tools
 - **Why use it?** Automates recon and scanning while keeping the human in control of exploits
@@ -28,11 +28,11 @@
 
 ### Key Features
 
-- **66 Tools** — Nmap, Metasploit, SQLMap, Nuclei, Hydra, Burp-compatible ZAP, and more
+- **63 Tools** — Nmap, Metasploit, SQLMap, Nuclei, Hydra, Burp-compatible ZAP, and more
 - **AI-Orchestrated** — Claude decides the next tool based on previous findings
 - **Safety First** — Allowlist, rate limiting, audit logs, and human-in-the-loop for destructive actions
 - **Auto Reports** — Correlate findings and generate professional pentest reports (MD/HTML/PDF)
-- **35 Workflows** — Pre-built prompts for full pentest, web app, AD, cloud, and more
+- **34 Workflows** — Pre-built prompts for full pentest, web app, AD, cloud, and more
 - **20 Resources** — Built-in OWASP Top 10, MITRE ATT&CK, PTES, and pentest checklists
 - **Stealth Layer** — Optional Tor/SOCKS5 proxy routing, UA rotation, and timing jitter
 
@@ -98,7 +98,7 @@ TENGU_TIER=core    make docker-build   # default
 TENGU_TIER=full    make docker-build   # everything
 ```
 
-> **All tiers include all 35 prompts and 20 resources** — only the binary tools differ.
+> **All tiers include all 34 prompts and 20 resources** — only the binary tools differ.
 
 <details>
 <summary>Manual Install (without Docker)</summary>
@@ -148,7 +148,9 @@ enabled = false  # Route traffic through Tor/proxy
 
 [stealth.proxy]
 enabled = false
-url = "socks5h://127.0.0.1:9050"
+type = "socks5h"
+host = "127.0.0.1"
+port = 9050
 
 [osint]
 shodan_api_key = ""  # Required for shodan_lookup
@@ -217,8 +219,8 @@ START → initializer → strategist ─┬─→ executor → analyst ─┬─
 
 ## Tool Catalog
 
-> `minimal` (17 tools, ~480MB) · `core` (47 tools, ~7GB, default) · `full` (66 tools, ~8GB)
-> Build with: `TENGU_TIER=<tier> make docker-build`. All tiers include all 35 prompts and 20 resources.
+> `minimal` (17 tools, ~480MB) · `core` (47 tools, ~7GB, default) · `full` (63 tools, ~8GB)
+> Build with: `TENGU_TIER=<tier> make docker-build`. All tiers include all 34 prompts and 20 resources.
 
 | Category | Tools | Count |
 |----------|-------|-------|
@@ -228,7 +230,8 @@ START → initializer → strategist ─┬─→ executor → analyst ─┬─
 | DNS | DNS Enumerate, DNSRecon, Subjack, WHOIS | 4 |
 | Injection Testing | SQLMap, Dalfox (XSS), GraphQL Security Check | 3 |
 | Brute Force | Hydra, John the Ripper, Hashcat, CeWL | 4 |
-| Exploitation | Metasploit (search, info, run, sessions), SearchSploit | 5 |
+| Exploitation | Metasploit (search, info, run, sessions, cmd), SearchSploit | 6 |
+| Social Engineering | SET credential harvester, QR code attack, payload generator | 3 |
 | OSINT | theHarvester, Shodan, WHOIS | 3 |
 | Secrets & Code | TruffleHog, Gitleaks | 2 |
 | Container & Cloud | Trivy, Checkov, ScoutSuite | 3 |
@@ -240,7 +243,7 @@ START → initializer → strategist ─┬─→ executor → analyst ─┬─
 | Utility | Tool checker, target validator | 2 |
 
 <details>
-<summary>Full tool list (66 tools)</summary>
+<summary>Full tool list (63 tools)</summary>
 
 ### Reconnaissance
 | Tool | Description |
@@ -293,6 +296,13 @@ START → initializer → strategist ─┬─→ executor → analyst ─┬─
 | `msf_sessions_list` | List active Metasploit sessions |
 | `msf_session_cmd` | Execute a command on an active session (shell/Meterpreter) |
 | `searchsploit_query` | Search Exploit-DB offline database |
+
+### Social Engineering
+| Tool | Description |
+|------|-------------|
+| `set_credential_harvester` | Clone a website and capture submitted credentials (authorized phishing simulations) |
+| `set_qrcode_attack` | Generate QR code pointing to a URL for physical social engineering assessments |
+| `set_payload_generator` | Generate social engineering payloads (PowerShell, HTA) for authorized campaigns |
 
 ### Brute Force
 | Tool | Description |
@@ -378,11 +388,12 @@ Pre-built workflow templates that guide Claude through complete engagements.
 | **Reports** | `executive_report`, `technical_report`, `full_pentest_report`, `finding_detail`, `risk_matrix`, `remediation_plan`, `retest_report` |
 | **Stealth/OPSEC** | `stealth_assessment`, `opsec_checklist` |
 | **Specialized** | `ad_assessment`, `api_security_assessment`, `container_assessment`, `cloud_assessment`, `wireless_assessment`, `bug_bounty_workflow`, `compliance_assessment` |
-| **Quick actions** | `explore_url`, `map_network`, `hunt_subdomains`, `find_vulns`, `find_secrets`, `go_stealth`, `crack_wifi`, `pwn_target` |
+| **Quick actions** | `explore_url`, `map_network`, `hunt_subdomains`, `find_vulns`, `find_secrets`, `go_stealth`, `crack_wifi`, `pwn_target`, `msf_exploit_workflow` |
+| **Social Engineering** | `social_engineering_assessment` |
 
 ---
 
-## Built-in Resources (19)
+## Built-in Resources (20)
 
 Static reference data loaded by Claude during engagements.
 
@@ -400,8 +411,13 @@ Static reference data loaded by Claude during engagements.
 | `mitre://attack/tactics` | MITRE ATT&CK Enterprise tactics + techniques |
 | `mitre://attack/technique/{T1xxx}` | Technique detail by ID |
 | `creds://defaults/{product}` | Default credentials database |
+| `payloads://{type}` | Curated payload lists by type (xss, sqli, lfi, ssti, etc.) |
+| `stealth://techniques` | Reference guide for operational security techniques |
+| `stealth://proxy-guide` | Step-by-step proxy and Tor configuration guide |
 | `tools://catalog` | Live tool availability status |
 | `tools://{tool}/usage` | Usage guide for nmap, nuclei, sqlmap, metasploit, trivy, amass |
+| `prompts://list` | List of all available prompts with descriptions |
+| `prompts://category/{category}` | Prompts filtered by category |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete reference for all 66 tools, 20 resources, and 35 prompts in Tengu.
+Complete reference for all 63 tools, 20 resources, and 34 prompts in Tengu.
 
 All tools require the target to be in the `[targets].allowed_hosts` allowlist
 configured in `tengu.toml`, unless explicitly noted otherwise.
@@ -1230,6 +1230,8 @@ Resources provide read-only reference data. Access via their URI.
 | `payloads://{type}` | Curated payload list by type | JSON array of payload strings |
 | `stealth://techniques` | Reference guide for operational security techniques | JSON object with technique descriptions |
 | `stealth://proxy-guide` | Step-by-step proxy and Tor configuration guide | JSON object with configuration steps |
+| `prompts://list` | List of all available prompts with descriptions | JSON array of prompt metadata |
+| `prompts://category/{category}` | Prompts filtered by category (e.g. `workflow`, `reporting`, `quick-actions`) | JSON array of matching prompts |
 
 ### `tools://{tool_name}/usage` Available Guides
 
@@ -1462,3 +1464,10 @@ Compare original findings against retest results to measure remediation effectiv
 | `hunt_subdomains` | Passive and active subdomain enumeration with takeover detection | `domain: str` |
 | `find_vulns` | Template-based vulnerability sweep using nuclei across a target | `target: str`, `severity: str` |
 | `pwn_target` | Full exploitation workflow: recon → vuln scan → exploit → post-exploitation checklist | `target: str` |
+| `msf_exploit_workflow` | Step-by-step Metasploit module selection, configuration, and execution workflow | `target: str`, `service: str` |
+
+### Social Engineering Prompts (v0.3.0)
+
+| Prompt | Description | Key Arguments |
+|--------|-------------|---------------|
+| `social_engineering_assessment` | Structured social engineering assessment covering phishing, pretexting, and physical access simulations | `target: str`, `scope: str` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,9 +10,9 @@ Tengu implements three MCP primitives:
 
 | Primitive | Count | Purpose |
 |-----------|-------|---------|
-| Tools     | 66    | Active operations: scanning, exploitation, analysis, stealth |
+| Tools     | 63    | Active operations: scanning, exploitation, analysis, stealth |
 | Resources | 20    | Read-only reference data: OWASP, PTES, MITRE ATT&CK, checklists, payloads |
-| Prompts   | 35    | Guided workflow templates for complex engagements |
+| Prompts   | 34    | Guided workflow templates for complex engagements |
 
 ---
 
@@ -123,7 +123,7 @@ graph TD
 
 ## Tool Categories and Coverage
 
-66 tools across 18 categories as of v0.2.2.
+63 tools across 19 categories as of v0.3.0.
 
 ```mermaid
 graph LR
@@ -162,12 +162,19 @@ graph LR
         XSS["xss_scan"]
     end
 
-    subgraph EXP["Exploitation (5)"]
+    subgraph EXP["Exploitation (6)"]
         MSS["msf_search"]
         MSI["msf_module_info"]
         MSR["msf_run_module"]
         MSSL["msf_sessions_list"]
+        MSSC["msf_session_cmd"]
         SEX["searchsploit_query"]
+    end
+
+    subgraph SOC["Social Engineering (3)"]
+        SCH["set_credential_harvester"]
+        SQR["set_qrcode_attack"]
+        SPG["set_payload_generator"]
     end
 
     subgraph BRF["Bruteforce (4)"]
@@ -365,7 +372,7 @@ implementation without changing any tool code.
 
 | Module | Description |
 |--------|-------------|
-| `server.py` | FastMCP server instance. Imports and registers all 66 tools, 20 resources, and 35 prompts. Contains the `main()` entry point. |
+| `server.py` | FastMCP server instance. Imports and registers all 63 tools, 20 resources, and 34 prompts. Contains the `main()` entry point. |
 | `config.py` | Loads `tengu.toml` with `tomllib`, applies env var overrides, returns a `TenguConfig` singleton. Contains default blocked hosts list. |
 | `types.py` | All shared Pydantic v2 models: network scan models (`Host`, `Port`, `ScanResult`), web models (`SecurityHeader`, `CORSResult`, `SSLResult`), finding models (`Finding`, `Evidence`), report models (`PentestReport`, `RiskMatrix`), CVE models (`CVERecord`, `CVSSMetrics`), tool status models (`ToolStatus`, `ToolsCheckResult`). |
 | `exceptions.py` | Custom exception hierarchy rooted at `TenguError`. Each exception carries structured data (tool name, target, returncode, etc.) for programmatic handling. |
@@ -401,5 +408,13 @@ implementation without changing any tool code.
 | `prompts/pentest_workflow.py` | Workflow prompts: `full_pentest` (7 PTES phases), `quick_recon` (7-step fast recon), `web_app_assessment` (OWASP OTG). |
 | `prompts/vuln_assessment.py` | Focused assessment prompts: injection, access control, cryptography, misconfiguration. |
 | `prompts/report_prompts.py` | Report prompts: executive, technical, full, remediation plan, finding detail, risk matrix, retest. |
-| `prompts/advanced_workflows.py` | Advanced prompts added in v0.2.0: osint_investigation, stealth_assessment, opsec_checklist, api_security_assessment, ad_assessment, container_assessment, cloud_assessment, bug_bounty_workflow, compliance_assessment, wireless_assessment. |
-| `prompts/quick_actions.py` | Quick action prompts added in v0.2.1: crack_wifi, explore_url, go_stealth, find_secrets, map_network, hunt_subdomains, find_vulns, pwn_target. |
+| `prompts/osint_workflow.py` | `osint_investigation` — structured OSINT gathering workflow. |
+| `prompts/stealth_prompts.py` | `stealth_assessment`, `opsec_checklist` — stealth and OPSEC engagement prompts. |
+| `prompts/api_assessment.py` | `api_security_assessment` — OWASP API Security Top 10 assessment workflow. |
+| `prompts/ad_assessment.py` | `ad_assessment` — Active Directory enumeration and attack path workflow. |
+| `prompts/container_assessment.py` | `container_assessment` — container image and runtime security assessment. |
+| `prompts/bug_bounty.py` | `bug_bounty_workflow` — scope-aware bug bounty hunting workflow. |
+| `prompts/compliance_assessment.py` | `compliance_assessment` — compliance-mapped assessment (PCI-DSS, ISO 27001, NIST). |
+| `prompts/wireless_assessment.py` | `wireless_assessment` — Wi-Fi reconnaissance, capture, and cracking workflow. |
+| `prompts/quick_actions.py` | Quick action prompts added in v0.2.1: crack_wifi, explore_url, go_stealth, find_secrets, map_network, hunt_subdomains, find_vulns, pwn_target, msf_exploit_workflow. |
+| `prompts/social_engineering.py` | `social_engineering_assessment` — social engineering assessment workflow added in v0.3.0. |

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -87,6 +87,10 @@ searchsploit = ""
 # Start RPC with: msfrpcd -P PASSWORD -a 127.0.0.1
 metasploit_rpc = "https://127.0.0.1:55553"
 
+# Social Engineering Toolkit (SET) — used by set_credential_harvester,
+# set_qrcode_attack, set_payload_generator
+setoolkit = ""
+
 
 # =============================================================================
 # [tools.defaults] — Default tool parameters
@@ -108,6 +112,40 @@ scan_timeout = 600
 # Default wordlist for ffuf_fuzz and directory fuzzing
 # Change to your preferred wordlist or a larger SecLists wordlist
 wordlist_path = "/usr/share/seclists/Discovery/Web-Content/common.txt"
+
+
+# =============================================================================
+# [stealth] — Optional anonymization and evasion layer
+# =============================================================================
+[stealth]
+
+# Set to true to enable the stealth layer (proxy routing, UA rotation, jitter)
+enabled = false
+
+[stealth.proxy]
+
+# Enable proxy routing for supported tools (nmap, nuclei, ffuf, etc.)
+enabled = false
+
+# Proxy type: socks5h, socks5, http
+type = "socks5h"
+
+# Proxy host and port
+host = "127.0.0.1"
+port = 9050
+
+[stealth.timing]
+
+# Minimum jitter delay (seconds) added between requests
+min_delay = 0.5
+
+# Maximum jitter delay (seconds)
+max_delay = 3.0
+
+[stealth.user_agent]
+
+# Rotate User-Agent header on each HTTP request
+rotate = true
 
 
 # =============================================================================
@@ -251,6 +289,7 @@ class TenguConfig(BaseModel):
     tools: ToolsConfig      # contains paths and defaults
     rate_limiting: RateLimitingConfig
     cve: CVEConfig
+    stealth: StealthConfig = Field(default_factory=StealthConfig)
 
     @property
     def effective_blocked_hosts(self) -> list[str]:
@@ -326,6 +365,37 @@ class CVEConfig(BaseModel):
     nvd_api_key: str = ""
     cache_path: str = "~/.tengu/cve_cache.db"
     cache_ttl_hours: int = 24
+```
+
+### `StealthConfig`
+
+```python
+class StealthProxyConfig(BaseModel):
+    enabled: bool = False
+    type: str = "socks5h"
+    host: str = "127.0.0.1"
+    port: int = 9050
+
+    @property
+    def url(self) -> str:
+        """Construct proxy URL from fields (e.g. socks5h://127.0.0.1:9050)."""
+        return f"{self.type}://{self.host}:{self.port}"
+
+
+class StealthTimingConfig(BaseModel):
+    min_delay: float = 0.5
+    max_delay: float = 3.0
+
+
+class StealthUserAgentConfig(BaseModel):
+    rotate: bool = True
+
+
+class StealthConfig(BaseModel):
+    enabled: bool = False
+    proxy: StealthProxyConfig = Field(default_factory=StealthProxyConfig)
+    timing: StealthTimingConfig = Field(default_factory=StealthTimingConfig)
+    user_agent: StealthUserAgentConfig = Field(default_factory=StealthUserAgentConfig)
 ```
 
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,7 @@ security review, and submit a pull request.
 ```bash
 git clone https://github.com/YOUR_FORK/tengu.git
 cd tengu
-git remote add upstream https://github.com/tengu-project/tengu.git
+git remote add upstream https://github.com/rfunix/tengu.git
 ```
 
 ### 2. Install Development Dependencies


### PR DESCRIPTION
## Summary

- Corrige contagens de tools (66 → 63) e prompts (35 → 34) em todos os documentos
- Substitui referência ao arquivo inexistente `advanced_workflows.py` pelos arquivos reais de prompts
- Adiciona seção Social Engineering (3 tools do SET + prompt `social_engineering_assessment`)
- Adiciona `msf_session_cmd` nas tabelas de Exploitation
- Adiciona `msf_exploit_workflow` nos Quick Actions
- Corrige formato do stealth config: campo `url` → campos separados (`type`, `host`, `port`)
- Atualiza contagem de resources (19 → 20) e adiciona 5 URIs faltantes (`payloads://`, `stealth://`, `prompts://`)
- Adiciona seção `[stealth]` completa na configuration-reference com subseções e modelos Pydantic
- Adiciona entrada v0.3.0 no CHANGELOG para os tools de Social Engineering
- Corrige URLs do repositório: `tengu-project/tengu` → `rfunix/tengu`

## Arquivos modificados

- `CLAUDE.md` — contagens, module map de prompts, stealth config
- `README.md` — badge, contagens, Social Engineering, resources
- `CHANGELOG.md` — URLs, v0.2.1 quick actions count, nova entrada v0.3.0
- `CONTRIBUTING.md` — contagens
- `docs/architecture.md` — primitives table, diagrama mermaid, module map table
- `docs/api-reference.md` — header, Social Engineering tools/prompts, resource URIs
- `docs/configuration-reference.md` — seção [stealth] completa, setoolkit, StealthConfig
- `docs/contributing.md` — URL upstream

## Test plan

- [x] `make lint` — 0 erros (nenhum `.py` modificado)
- [x] Grep por `66 tool`, `66 MCP`, `35 prompt`, `35 MCP`, `tengu-project/tengu`, `advanced_workflows` — sem resultados

🤖 Generated with [Claude Code](https://claude.com/claude-code)