### PR TITLE
fix(docs): correct pre-demo commands in demo-script.md

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -11,13 +11,13 @@
 
 ```bash
 # Start the environment
-TENGU_TIER=full docker compose --profile lab up -d
+make docker-lab
 
 # Confirm everything is up
 docker compose ps
 
-# Verify Juice Shop is reachable
-curl -s http://juice-shop:3000/ | grep -o "OWASP Juice Shop"
+# Verify Juice Shop is reachable (juice-shop is internal to the Docker network)
+docker exec $(docker compose ps -q tengu) curl -s http://juice-shop:3000/ | grep -o "OWASP Juice Shop"
 ```
 
 **`tengu.toml` — add the target to the allowlist:**


### PR DESCRIPTION
- Replace `TENGU_TIER=full docker compose --profile lab up -d` with `make docker-lab`; TENGU_TIER is a build arg, not a runtime var, and passing it at `up` time looks for a non-existent `tengu:full` image
- Replace `curl http://juice-shop:3000` (host-side, unresolvable) with `docker exec $(docker compose ps -q tengu) curl ...` since juice-shop is only reachable within the tengu-net Docker network and has no host port mapping

## Summary

<!-- Brief description of what this PR changes and why. -->

## Type of Change

- [ ] Bug fix
- [ ] New tool
- [ ] Tool improvement
- [ ] Infrastructure / CI
- [ ] Documentation
- [ ] Refactoring (no behavior change)

## Checklist

### Code Quality
- [ ] `make lint` passes (ruff — 0 errors)
- [ ] `make typecheck` passes (mypy strict — 0 errors)
- [ ] `make format` applied

### Security (mandatory for all tool changes)
- [ ] No `shell=True` anywhere in new/changed code
- [ ] All user inputs sanitized via `sanitize_*` from `tengu.security.sanitizer`
- [ ] Allowlist check (`allowlist.check(target)`) present for tools accepting a target
- [ ] Rate limiting via `async with rate_limited("tool_name")` applied
- [ ] Audit logging (`log_tool_call`) with `started` + `completed`/`failed` entries

### Tests
- [ ] Unit tests added/updated in `tests/unit/`
- [ ] Security/injection tests added/updated in `tests/security/` (for new tools)
- [ ] `make test` passes (all unit + security tests green)

### New Tool (if applicable)
- [ ] Tool file created in `src/tengu/tools/<category>/<tool>.py`
- [ ] Tool registered in `server.py` (`mcp.tool()(my_tool)`)
- [ ] Added to `scripts/install-tools.sh`
- [ ] README badge count updated
- [ ] README tool table updated
- [ ] CLAUDE.md tool count updated

## Testing Notes

<!-- Describe how you tested this. Include any manual steps, edge cases checked, etc. -->

## Related Issues

<!-- Link any related issues: Closes #123, Relates to #456 -->
