### PR TITLE
feat(make): add docker-agent-logs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: test test-unit test-security test-integration test-all coverage
 .PHONY: run run-sse run-dev inspect clean doctor
 .PHONY: docker-build docker-up docker-down docker-logs docker-shell
-.PHONY: docker-lab docker-full docker-pentest docker-agent docker-agent-haiku docker-agent-sonnet docker-clean
+.PHONY: docker-lab docker-full docker-pentest docker-agent docker-agent-haiku docker-agent-sonnet docker-agent-logs docker-clean
 .PHONY: docker-rebuild docker-rebuild-tengu docker-reset
 
 # ============================================================
@@ -135,6 +135,9 @@ docker-agent-haiku: ## Run autonomous agent with claude-haiku-4-5 (cheaper, fast
 docker-agent-sonnet: ## Run autonomous agent with claude-sonnet-4-6 (default, balanced)
 	TENGU_AGENT_MODEL=claude-sonnet-4-6 TENGU_AGENT_MAX_TOKENS=4096 \
 		docker compose --profile agent run --rm tengu-agent
+
+docker-agent-logs: ## Tail logs from the agent and tengu server (useful when agent runs in background)
+	docker compose logs -f tengu tengu-agent
 
 docker-clean: ## Remove Docker images and volumes
 	docker compose down -v --rmi local


### PR DESCRIPTION
## Summary

- Add `make docker-agent-logs` to tail combined logs from `tengu` + `tengu-agent` containers

Useful when the agent runs in the background (e.g. via `docker compose up`) or for post-mortem debugging after a run.

## Test plan

- [ ] `make docker-agent-logs` — tails logs from both containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)