### PR TITLE
fix(docker): add juice-shop and dvwa to allowed_hosts in docker/tengu.toml

### DIFF
--- a/docker/tengu.toml
+++ b/docker/tengu.toml
@@ -9,6 +9,8 @@ allowed_hosts = [
     "172.16.0.0/12",    # Docker bridge + custom networks (172.17-20.x.x)
     "192.168.0.0/16",   # Host network / lab ranges
     "10.0.0.0/8",       # VPN / cloud lab
+    "juice-shop",       # Lab target (docker compose --profile lab)
+    "dvwa",             # Lab target (docker compose --profile lab)
 ]
 
 # Always blocked, even if listed in allowed_hosts


### PR DESCRIPTION
## Summary

- Add `juice-shop` and `dvwa` to `allowed_hosts` in `docker/tengu.toml`

## Problem

The Docker `tengu.toml` only contained CIDR ranges. When the autonomous agent targets `juice-shop` (the lab container), the allowlist rejects it because the hostname doesn't match any CIDR.

## Test plan

- [ ] `TENGU_AGENT_TARGET=juice-shop docker compose --profile lab --profile agent up -d` proceeds past the allowlist check

🤖 Generated with [Claude Code](https://claude.com/claude-code)