### PR TITLE
fix(agent): expand allowlist and add docker report commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,12 @@ docker-agent-sonnet: ## Run autonomous agent with claude-sonnet-4-6 (default, ba
 docker-agent-logs: ## Tail logs from the agent and tengu server (useful when agent runs in background)
 	docker compose logs -f tengu tengu-agent
 
+docker-reports: ## List reports generated inside Docker (stored in tengu-output volume)
+	docker run --rm -v tengu-output:/app/output alpine ls -lh /app/output/
+
+docker-report: ## Cat a specific report (REPORT=filename.md)
+	docker run --rm -v tengu-output:/app/output alpine cat /app/output/$(REPORT)
+
 docker-clean: ## Remove Docker images and volumes
 	docker compose down -v --rmi local
 


### PR DESCRIPTION
## Summary

- **`tengu.toml`**: expand `allowed_hosts` to include `juice-shop`, `juice-shop.local`, and `172.20.0.0/24` — the autonomous agent was hitting `TargetNotAllowedError` because it tried the `.local` suffix and the full `/24` subnet
- **`Makefile`**: add two targets for inspecting reports stored in the `tengu-output` Docker volume:
  - `make docker-reports` — lists all generated reports
  - `make docker-report REPORT=<filename>` — cats a specific report

## Root cause

Analysis of `pentest-juice-shop-2026-03-03.md` showed repeated `TargetNotAllowedError` findings:
- Agent tried `juice-shop.local` (only `juice-shop` was allowed)
- Agent tried `172.20.0.0/24` subnet scan (only `172.20.0.5` was allowed)
- Agent tried `juice-shop:3000` — correctly rejected by sanitizer (port in hostname)

## Test plan

- [ ] Run `make docker-agent` and verify no `TargetNotAllowedError` for lab targets
- [ ] Run `make docker-reports` and confirm report listing works
- [ ] Run `make docker-report REPORT=<file>` and confirm output

🤖 Generated with [Claude Code](https://claude.com/claude-code)