### PR TITLE
feat: bug bounty UX — wildcard hints, finding dedup, focused prompts

### DIFF
--- a/src/tengu/prompts/bug_bounty.py
+++ b/src/tengu/prompts/bug_bounty.py
@@ -3,6 +3,73 @@
 from __future__ import annotations
 
 
+def bug_bounty_focused(target: str, scope: str = "web") -> str:
+    """Focused bug bounty pipeline — minimal tools, maximum signal.
+
+    Uses 5-6 tools in a strict pipeline to avoid context overload and
+    false positives. Best for time-boxed solo hunting sessions.
+
+    Args:
+        target: Target domain (must be in tengu.toml allowed_hosts).
+                Use '*.target.com' in allowed_hosts for subdomain coverage.
+        scope: Focus area — web (default), api, network.
+    """
+    phase3_scan = {
+        "web": f'3. `nuclei_scan(target="https://{target}", severity=["high","critical"])` — template-based vulnerability detection',
+        "api": f'3. `nuclei_scan(target="https://{target}", tags=["api","exposure"], severity=["high","critical"])` — API-specific templates',
+        "network": '3. `cve_search(keyword="<service-name> <version>")` — CVE lookup for each service found in Phase 1',
+    }
+
+    phase4_exploit = {
+        "web": f"""4. **Conditional — pick ONE based on Phase 3 results:**
+   - If SQL injection indicators found: `sqlmap_scan(url="https://{target}/<endpoint>?param=test", level=1, risk=1)`
+   - If XSS indicators found: `xss_scan(url="https://{target}/<endpoint>?param=test")`
+   - If neither: skip this phase (no blind testing — reduces false positives)""",
+        "api": f"""4. **Conditional — pick ONE based on Phase 3 results:**
+   - If injection indicators: `sqlmap_scan(url="https://{target}/api/<endpoint>?param=test")`
+   - If parameter issues: `arjun_discover(url="https://{target}/api/")` — hidden params
+   - If neither: skip""",
+        "network": """4. **Conditional — only if CVEs found in Phase 3:**
+   - `searchsploit_query(query="<software> <version>")` — check exploit availability
+   - Document findings without active exploitation""",
+    }
+
+    return f"""# Focused Bug Bounty: {target} | Scope: {scope.upper()}
+
+## IMPORTANT: Allowlist Setup
+Before starting, ensure your tengu.toml has:
+```toml
+allowed_hosts = ["*.{target}"]
+```
+This allows all discovered subdomains. Without the wildcard, subfinder results
+will be blocked by the allowlist.
+
+## Pipeline (5-6 tools max — strict order)
+
+### Phase 1 — Recon (2 tools)
+1. `subfinder_enum(domain="{target}")` — passive subdomain enumeration
+2. `nmap_scan(target="{target}", scan_type="version", ports="80,443,8080,8443")` — service fingerprint
+
+### Phase 2 — Scan (1 tool)
+{phase3_scan.get(scope, phase3_scan["web"])}
+
+### Phase 3 — Exploit (1 tool, conditional)
+{phase4_exploit.get(scope, phase4_exploit["web"])}
+
+### Phase 4 — Analysis (2 tools)
+5. `correlate_findings(findings=[...])` — deduplicate and identify attack chains
+6. `score_risk(findings=[...])` — prioritize by CVSS
+
+## Decision Rules
+- **WAF detected in nuclei output?** → Note in report, adjust expectations
+- **No findings in Phase 2?** → Stop. Do NOT add more scanners hoping for results
+- **Multiple tools report same vuln?** → `correlate_findings` will deduplicate automatically
+- **Subdomain blocked by allowlist?** → Add `*.{target}` to tengu.toml
+
+## Tool Count: {5 if scope == "network" else 6} max
+Resist the urge to add more tools. More tools = more noise = worse results."""
+
+
 def bug_bounty_workflow(target: str, focus: str = "web") -> str:
     """Optimized bug bounty reconnaissance and testing workflow.
 

--- a/src/tengu/prompts/pentest_workflow.py
+++ b/src/tengu/prompts/pentest_workflow.py
@@ -3,6 +3,68 @@
 from __future__ import annotations
 
 
+def focused_pentest(target: str, focus_area: str = "web") -> str:
+    """Focused penetration test with minimal tool pipeline.
+
+    Unlike full_pentest which uses 12-20 tools, this prompt uses a tight
+    pipeline of 3-5 tools tailored to the focus area. Reduces false
+    positives and keeps the AI's context window clean.
+
+    Args:
+        target: Primary target (IP, domain, or URL).
+        focus_area: Assessment type — web, network, or api.
+    """
+    pipelines = {
+        "web": f"""## Web Application Focused Pentest: {target}
+
+### Pipeline (5 tools)
+
+1. **Recon**: `nmap_scan(target="{target}", scan_type="version", ports="80,443,8080,8443")` — identify web services
+2. **Scan**: `nuclei_scan(target="https://{target}", severity=["medium","high","critical"])` — template-based detection
+3. **Exploit (conditional)**:
+   - If SQL injection indicators: `sqlmap_scan(url="https://{target}/<endpoint>?param=test")`
+     Note: sqlmap uses 'url' parameter, NOT 'target'
+   - If XSS indicators: `xss_scan(url="https://{target}/<endpoint>?param=test")`
+     Note: xss_scan uses 'url' parameter, NOT 'target'
+   - Pick ONE based on findings — do not run both blindly
+4. **Correlate**: `correlate_findings(findings=[...])` — deduplicate cross-tool findings
+5. **Score**: `score_risk(findings=[...])` — risk prioritization
+
+### Decision Gates
+- No findings in step 2? → Report clean scan, do NOT add more scanners
+- WAF detected? → Note in report, expect higher false negative rate
+- Multiple tools report same issue? → correlate_findings handles deduplication""",
+        "network": f"""## Network Focused Pentest: {target}
+
+### Pipeline (3 tools)
+
+1. **Discovery**: `nmap_scan(target="{target}", scan_type="version", timing="T4", ports="1-1024,3306,5432,8080,8443")` — full service map
+2. **CVE Lookup**: For each service found:
+   `cve_search(keyword="<software> <version>")` — search NVD
+   Note: cve_search uses 'keyword' parameter, NOT 'query'
+3. **Correlate**: `correlate_findings(findings=[...])` — identify attack chains
+
+### Decision Gates
+- Critical CVEs found? → `searchsploit_query(query="<CVE>")` for exploit availability
+- No services found? → Verify target is up, try UDP scan""",
+        "api": f"""## API Focused Pentest: {target}
+
+### Pipeline (4 tools)
+
+1. **Probe**: `httpx_probe(targets=["{target}"])` — discover live API endpoints and status codes
+2. **Discover**: `arjun_discover(url="https://{target}/api/", method="GET")` — hidden parameter discovery
+3. **Scan**: `nuclei_scan(target="https://{target}", tags=["api","exposure"], severity=["medium","high","critical"])` — API-specific templates
+4. **Correlate**: `correlate_findings(findings=[...])` — deduplicate and prioritize
+
+### Decision Gates
+- Hidden params found? → Test with sqlmap (use 'url' parameter, not 'target')
+- Auth endpoints detected? → Test for IDOR, JWT issues manually
+- GraphQL endpoint? → `graphql_security_check(url="https://{target}/graphql")`""",
+    }
+
+    return pipelines.get(focus_area, pipelines["web"])
+
+
 def full_pentest(
     target: str,
     scope: str = "full",

--- a/src/tengu/prompts/quick_actions.py
+++ b/src/tengu/prompts/quick_actions.py
@@ -94,19 +94,24 @@ def explore_url(url: str, depth: str = "normal") -> str:
 ## Phase 2 — Technology Fingerprint (always)
 5. `whatweb_scan(url="{url}")` — detect CMS, frameworks, server version, JavaScript libraries
 6. Based on detected tech, check for CMS-specific vulnerabilities:
-   - WordPress: `wpscan_scan(url="{url}")`
-   - Testssl: `testssl_check(host="{url.split("//")[-1].split("/")[0]}")`
+   - WordPress detected? → `wpscan_scan(url="{url}")`
+   - No CMS detected? → Skip this step (do NOT run wpscan on non-WordPress sites)
 {
-        '''
-## Phase 3 — Directory and File Fuzzing (normal + deep)
+        f'''
+## Phase 3 — Discovery (normal + deep — 2 tools, not 3)
 7. `ffuf_fuzz(url="{url}/FUZZ", wordlist="/usr/share/seclists/Discovery/Web-Content/common.txt")` — hidden paths
-8. `feroxbuster_scan(target="{url}", depth=3)` — recursive discovery (finds /api/v1/users/profile that ffuf misses)
-9. `katana_crawl(target="{url}", depth=3)` — crawl all reachable links and form actions
-10. Look for: admin panels, backup files (.bak, .old), config files, API endpoints
+   Note: ffuf uses 'url' parameter with FUZZ placeholder
+8. `katana_crawl(target="{url}", depth=3)` — crawl all reachable links and form actions
+   (Skip feroxbuster — ffuf + katana cover the same ground with less noise)
 
-## Phase 4 — Vulnerability Scanning (normal + deep)
-11. `nuclei_scan(target="{url}", severity=["medium","high","critical"])` — known CVEs and misconfigs
-12. `nikto_scan(url="{url}")` — web server misconfigurations, dangerous files
+## Phase 4 — Vulnerability Scanning (normal + deep — 1 tool)
+9. `nuclei_scan(target="{url}", severity=["medium","high","critical"])` — known CVEs and misconfigs
+   (Skip nikto — nuclei covers most nikto checks with higher accuracy and lower false positives)
+
+## Conditional Decisions
+- WAF detected in Phase 1? → Note it, expect false negatives in Phase 4
+- No web server on target? → Skip Phases 3-4 entirely
+- API-only endpoint? → Replace ffuf with `arjun_discover(url="{url}")`
 '''
         if depth in ("normal", "deep")
         else ""
@@ -138,11 +143,21 @@ def explore_url(url: str, depth: str = "normal") -> str:
 - `correlate_findings(findings=[...])` — identify attack chains
 
 ## Quick Reference
-| Depth | Tools Used |
-|-------|-----------|
-| quick | wafw00f_scan, analyze_headers, test_cors, ssl_tls_check, whatweb_scan |
-| normal | + ffuf_fuzz, feroxbuster_scan, katana_crawl, nuclei_scan, nikto_scan |
-| deep | + sqlmap_scan, xss_scan, commix_scan, crlfuzz_scan, arjun_discover, graphql_security_check, httrack_mirror |"""
+| Depth | Tools Used | Count |
+|-------|-----------|-------|
+| quick | wafw00f_scan, analyze_headers, test_cors, ssl_tls_check, whatweb_scan | 5 |
+| normal | + ffuf_fuzz, katana_crawl, nuclei_scan | 8 |
+| deep | + sqlmap_scan, xss_scan, commix_scan, crlfuzz_scan, arjun_discover, graphql_security_check, httrack_mirror | 15 |
+
+## Parameter Quick Reference
+| Tool | URL param name | Example |
+|------|---------------|---------|
+| feroxbuster_scan | `target` | `feroxbuster_scan(target="https://...")` |
+| sqlmap_scan | `url` | `sqlmap_scan(url="https://...?q=test")` |
+| xss_scan | `url` | `xss_scan(url="https://...?q=test")` |
+| commix_scan | `url` | `commix_scan(url="https://...?host=test")` |
+| cve_search | `keyword` | `cve_search(keyword="nginx 1.18")` |
+| nmap_scan | `target` | `nmap_scan(target="example.com")` |"""
 
 
 def go_stealth(proxy_url: str = "") -> str:

--- a/src/tengu/security/allowlist.py
+++ b/src/tengu/security/allowlist.py
@@ -17,6 +17,34 @@ from tengu.exceptions import TargetNotAllowedError
 logger = structlog.get_logger(__name__)
 
 
+def _suggest_wildcard(host: str, allowed: list[str]) -> str | None:
+    """Suggest a wildcard pattern if *host* is a subdomain of an allowed entry.
+
+    Returns a hint string like ``"*.example.com"`` when the rejected host is
+    ``sub.example.com`` and ``"example.com"`` is already in the allowlist.
+    Returns ``None`` when no useful suggestion can be made.
+    """
+    parts = host.split(".")
+    if len(parts) < 2:
+        return None
+
+    for pattern in allowed:
+        # Skip patterns that are already wildcards, CIDRs, or IPs
+        if pattern.startswith("*") or "/" in pattern:
+            continue
+        try:
+            ipaddress.ip_address(pattern)
+            continue  # it's an IP, not a domain
+        except ValueError:
+            pass
+
+        # Check if the host is a subdomain of this allowed domain
+        if host != pattern and host.endswith(f".{pattern}"):
+            return f"*.{pattern}"
+
+    return None
+
+
 def _extract_host(target: str) -> str:
     """Extract the hostname/IP from a target (URL, IP, domain, CIDR)."""
     target = target.strip()
@@ -111,10 +139,15 @@ class TargetAllowlist:
                     log.debug("Target allowed", pattern=pattern)
                     return
             log.warning("Target not in allowlist")
-            raise TargetNotAllowedError(
-                target,
-                "not in allowed_hosts. Add it to tengu.toml [targets].allowed_hosts",
-            )
+            hint = _suggest_wildcard(host, self._allowed)
+            if hint:
+                msg = (
+                    f"not in allowed_hosts. Hint: use '{hint}' to allow all "
+                    f"subdomains. Add to tengu.toml [targets].allowed_hosts"
+                )
+            else:
+                msg = "not in allowed_hosts. Add it to tengu.toml [targets].allowed_hosts"
+            raise TargetNotAllowedError(target, msg)
 
         # Allowlist is empty — warn but allow (useful for initial setup)
         log.warning(

--- a/src/tengu/server.py
+++ b/src/tengu/server.py
@@ -18,7 +18,7 @@ from starlette.responses import JSONResponse
 from tengu.executor.registry import check_all
 from tengu.prompts.ad_assessment import ad_assessment
 from tengu.prompts.api_assessment import api_security_assessment
-from tengu.prompts.bug_bounty import bug_bounty_workflow
+from tengu.prompts.bug_bounty import bug_bounty_focused, bug_bounty_workflow
 from tengu.prompts.compliance_assessment import compliance_assessment
 from tengu.prompts.container_assessment import cloud_assessment, container_assessment
 
@@ -26,7 +26,12 @@ from tengu.prompts.container_assessment import cloud_assessment, container_asses
 from tengu.prompts.osint_workflow import osint_investigation
 
 # Workflow prompts
-from tengu.prompts.pentest_workflow import full_pentest, quick_recon, web_app_assessment
+from tengu.prompts.pentest_workflow import (
+    focused_pentest,
+    full_pentest,
+    quick_recon,
+    web_app_assessment,
+)
 
 # Quick action prompts (v0.2.1)
 from tengu.prompts.quick_actions import (
@@ -748,6 +753,8 @@ mcp.prompt()(ad_assessment)
 mcp.prompt()(container_assessment)
 mcp.prompt()(cloud_assessment)
 mcp.prompt()(bug_bounty_workflow)
+mcp.prompt()(bug_bounty_focused)
+mcp.prompt()(focused_pentest)
 mcp.prompt()(compliance_assessment)
 mcp.prompt()(wireless_assessment)
 

--- a/src/tengu/tools/analysis/correlate.py
+++ b/src/tengu/tools/analysis/correlate.py
@@ -12,6 +12,119 @@ from tengu.tools.analysis.scoring import (
     score_to_rating,
 )
 
+# Per-tool confidence weights — how reliable is each tool's finding?
+# 1.0 = confirmed exploitable, 0.5 = informational / high false-positive rate
+_TOOL_CONFIDENCE: dict[str, float] = {
+    "sqlmap": 0.95,
+    "nuclei": 0.85,
+    "dalfox": 0.80,
+    "nmap": 0.90,
+    "nikto": 0.50,
+    "ffuf": 0.70,
+    "feroxbuster": 0.70,
+    "commix": 0.85,
+    "hydra": 0.90,
+    "wpscan": 0.75,
+    "gobuster": 0.65,
+    "trivy": 0.80,
+    "gitleaks": 0.75,
+    "trufflehog": 0.85,
+    "testssl": 0.80,
+    "wafw00f": 0.70,
+    "crlfuzz": 0.75,
+    "whatweb": 0.60,
+    "arjun": 0.65,
+    "katana": 0.60,
+    "searchsploit": 0.70,
+    "metasploit": 0.95,
+    "zap": 0.75,
+}
+
+DEFAULT_CONFIDENCE = 0.60
+
+
+def _deduplicate_findings(
+    findings: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Deduplicate findings reported by multiple tools on the same asset.
+
+    Groups findings by ``(affected_asset, owasp_category)`` or
+    ``(affected_asset, cve_id)``.  When multiple tools report the same
+    finding, the one with the highest tool confidence is kept; the others
+    are recorded as *conflicts*.
+
+    Returns:
+        ``(deduplicated, conflicts)`` — *conflicts* lists cases where
+        tools disagreed or duplicated a finding.
+    """
+    # Build groups keyed by (asset, category_or_cve)
+    groups: dict[tuple[str, str], list[dict]] = {}
+
+    for f in findings:
+        asset = f.get("affected_asset", f.get("url", "unknown"))
+        # Try CVE ID first (most precise), then OWASP category
+        cve_ids = f.get("cve_ids") or f.get("cve_id")
+        owasp = f.get("owasp_category", "")
+        if isinstance(owasp, list):
+            owasp = owasp[0] if owasp else ""
+
+        if cve_ids:
+            if isinstance(cve_ids, list):
+                for cve in cve_ids:
+                    key = (str(asset), str(cve))
+                    groups.setdefault(key, []).append(f)
+            else:
+                key = (str(asset), str(cve_ids))
+                groups.setdefault(key, []).append(f)
+        elif owasp:
+            key = (str(asset), str(owasp))
+            groups.setdefault(key, []).append(f)
+        else:
+            # No grouping key — keep as-is in a unique bucket
+            key = (str(asset), f"_unique_{id(f)}")
+            groups[key] = [f]
+
+    deduplicated: list[dict] = []
+    conflicts: list[dict] = []
+
+    for (asset, group_key), group in groups.items():
+        if len(group) == 1:
+            deduplicated.append(group[0])
+            continue
+
+        # Multiple tools — pick the one with highest confidence
+        scored = sorted(
+            group,
+            key=lambda f: _TOOL_CONFIDENCE.get(f.get("tool", ""), DEFAULT_CONFIDENCE),
+            reverse=True,
+        )
+        best = scored[0]
+        deduplicated.append(best)
+
+        # Record the conflict
+        conflicts.append(
+            {
+                "affected_asset": asset,
+                "group_key": group_key,
+                "kept": {
+                    "tool": best.get("tool", "unknown"),
+                    "severity": best.get("severity", "info"),
+                    "confidence": _TOOL_CONFIDENCE.get(best.get("tool", ""), DEFAULT_CONFIDENCE),
+                },
+                "duplicates": [
+                    {
+                        "tool": f.get("tool", "unknown"),
+                        "severity": f.get("severity", "info"),
+                        "confidence": _TOOL_CONFIDENCE.get(f.get("tool", ""), DEFAULT_CONFIDENCE),
+                    }
+                    for f in scored[1:]
+                ],
+            }
+        )
+
+    return deduplicated, conflicts
+
+
 # Attack chain patterns — combinations of findings that suggest a viable attack path
 _ATTACK_CHAINS: list[dict] = [
     {
@@ -82,8 +195,9 @@ async def correlate_findings(
             "message": "No findings to correlate.",
         }
 
-    # Parse findings into Finding objects where possible
-    parsed: list[dict] = findings
+    # Deduplicate findings from multiple tools on the same asset
+    parsed, dedup_conflicts = _deduplicate_findings(findings)
+    deduplicated_count = len(findings) - len(parsed)
 
     # Count by severity
     severity_counts: dict[str, int] = {}
@@ -154,6 +268,9 @@ async def correlate_findings(
     return {
         "tool": "correlate_findings",
         "findings_analyzed": len(parsed),
+        "original_findings_count": len(findings),
+        "deduplicated_count": deduplicated_count,
+        "conflicts": dedup_conflicts,
         "severity_breakdown": severity_counts,
         "tools_used": tools_used,
         "owasp_categories_present": sorted(owasp_present),

--- a/src/tengu/tools/analysis/cve_tools.py
+++ b/src/tengu/tools/analysis/cve_tools.py
@@ -70,11 +70,15 @@ async def cve_search(
 ) -> dict:
     """Search CVEs by keyword, product, CPE, or severity.
 
+    IMPORTANT: The search term parameter is named 'keyword' (not 'query').
+    Call as: cve_search(keyword="apache log4j")
+
     Queries the NVD database for matching CVEs. Results are cached
     locally for 24 hours to respect API rate limits.
 
     Args:
         keyword: Search term (e.g. "apache log4j", "OpenSSL", "nginx 1.18").
+                 MUST be named 'keyword' (not 'query').
         cpe_name: CPE 2.3 identifier (e.g. "cpe:2.3:a:apache:log4j:2.14.0:*:*:*:*:*:*:*").
         severity: Filter by CVSS severity: LOW, MEDIUM, HIGH, CRITICAL.
         days_back: Only return CVEs published in the last N days.

--- a/src/tengu/tools/analysis/scoring.py
+++ b/src/tengu/tools/analysis/scoring.py
@@ -21,6 +21,7 @@ def calculate_risk_score(
     *,
     attack_chains: list[dict] | None = None,
     context_multiplier: float = 1.0,
+    tool_confidence: dict[str, float] | None = None,
 ) -> float:
     """Calculate a unified risk score (0-10) from findings.
 
@@ -28,7 +29,8 @@ def calculate_risk_score(
         1. For each finding, use its ``cvss_score`` if present, otherwise
            fall back to the fixed severity weight.
         2. Exclude informational findings to avoid diluting the score.
-        3. Compute the weighted average of all scored findings.
+        3. Compute the weighted average of all scored findings, optionally
+           weighted by per-tool confidence when ``tool_confidence`` is given.
         4. Add a boost for identified attack chains (0.5 per chain, max 2.0).
         5. Add a boost for each critical finding (0.3 each, max 1.5).
         6. Apply the optional context multiplier (e.g. 1.2 for external targets).
@@ -39,6 +41,9 @@ def calculate_risk_score(
                   ``cvss_score`` is optional but preferred.
         attack_chains: Optional list of identified attack chain dicts.
         context_multiplier: Multiplier for engagement context (default 1.0).
+        tool_confidence: Optional mapping of tool name → confidence weight
+                         (0.0–1.0). When provided, each finding's score is
+                         multiplied by its tool's confidence before averaging.
 
     Returns:
         Risk score between 0.0 and 10.0.
@@ -58,15 +63,22 @@ def calculate_risk_score(
         for f in scored_or_all
     ]
 
-    # Coerce to float safely
+    # Coerce to float safely and apply tool confidence scaling
     safe_scores: list[float] = []
-    for s in cvss_scores:
+    for i, s in enumerate(cvss_scores):
         try:
-            safe_scores.append(float(s))  # type: ignore[arg-type]
+            score = float(s)  # type: ignore[arg-type]
         except (ValueError, TypeError):
-            safe_scores.append(0.0)
+            score = 0.0
 
-    # Step 3: weighted average
+        # Scale each score by tool confidence when provided
+        if tool_confidence:
+            tool_name = scored_or_all[i].get("tool", "")
+            score *= tool_confidence.get(tool_name, 1.0)
+
+        safe_scores.append(score)
+
+    # Step 3: average of (optionally confidence-scaled) scores
     base_score = sum(safe_scores) / len(safe_scores) if safe_scores else 0.0
 
     # Step 4: attack chain boost

--- a/src/tengu/tools/injection/commix.py
+++ b/src/tengu/tools/injection/commix.py
@@ -33,11 +33,15 @@ async def commix_scan(
 ) -> dict:
     """Test a URL for OS command injection vulnerabilities using Commix.
 
+    IMPORTANT: The target parameter is named 'url' (not 'target').
+    Always call as: commix_scan(url="https://example.com/ping?host=test")
+
     Commix (command injection exploiter) automates the detection of OS command
     injection flaws in web applications. Requires explicit authorization.
 
     Args:
         url: Target URL to test (e.g. "https://example.com/ping?host=test").
+             MUST be named 'url' (not 'target').
         method: HTTP method: GET or POST.
         data: POST data string (e.g. "param=value").
         level: Detection level (1-3). Default: 1.

--- a/src/tengu/tools/injection/xss.py
+++ b/src/tengu/tools/injection/xss.py
@@ -31,11 +31,15 @@ async def xss_scan(
 ) -> dict:
     """Test for Cross-Site Scripting (XSS) vulnerabilities using Dalfox.
 
+    IMPORTANT: The target parameter is named 'url' (not 'target').
+    Always call as: xss_scan(url="https://example.com/search?q=test")
+
     Dalfox is a powerful XSS scanner that detects reflected, stored, and
     DOM-based XSS vulnerabilities using pattern analysis and DOM parsing.
 
     Args:
         url: Target URL to test (e.g. "https://example.com/search?q=test").
+             MUST be named 'url' (not 'target').
         parameter: Specific parameter to focus testing on.
                    If empty, tests all parameters found in the URL.
         cookie: Session cookie for authenticated testing

--- a/src/tengu/tools/recon/nmap.py
+++ b/src/tengu/tools/recon/nmap.py
@@ -45,6 +45,10 @@ async def nmap_scan(
 ) -> dict:
     """Scan a target for open ports, services, and versions using Nmap.
 
+    IMPORTANT: Available parameters are: target, ports, scan_type, timing,
+    os_detection, scripts, timeout. There is NO 'flags' parameter — use
+    scan_type for scan technique and scripts for NSE scripts.
+
     Args:
         target: IP address, hostname, CIDR range, or URL to scan.
         ports: Port specification (e.g. "80", "22-443", "22,80,443", "1-65535").

--- a/src/tengu/tools/web/feroxbuster.py
+++ b/src/tengu/tools/web/feroxbuster.py
@@ -54,11 +54,15 @@ async def feroxbuster_scan(
 ) -> dict:
     """Perform recursive content discovery using Feroxbuster.
 
+    IMPORTANT: The URL parameter is named 'target' (not 'url').
+    Pass the full URL with scheme: target="https://example.com".
+
     Unlike Gobuster or FFuf, Feroxbuster recursively discovers directories,
     automatically crawling into discovered paths to find nested content.
 
     Args:
         target: Target URL to scan (e.g. "https://example.com").
+                MUST be named 'target' (not 'url').
         wordlist: Path to wordlist file.
         extensions: Comma-separated file extensions (e.g. "php,html,txt").
         threads: Number of concurrent threads (default 50, max 100).

--- a/tengu.toml
+++ b/tengu.toml
@@ -5,7 +5,14 @@ audit_log_path = "./logs/tengu-audit.log"
 
 [targets]
 # Allowed hosts/CIDRs for scanning — REQUIRED before running any scan
-# Examples: "example.com", "*.example.com", "192.168.1.0/24", "10.0.0.0/8"
+#
+# Matching rules:
+#   "example.com"        → exact match only (sub.example.com will be BLOCKED)
+#   "*.example.com"      → wildcard: matches any subdomain (sub.example.com, a.b.example.com)
+#   "192.168.1.0/24"     → CIDR: matches any IP in the range
+#   "10.0.0.1"           → exact IP match
+#
+# Tip: For bug bounty, use "*.target.com" to allow all discovered subdomains.
 allowed_hosts = ["juice-shop", "juice-shop.local", "172.20.0.0/24"]
 
 # Always blocked, even if listed in allowed_hosts

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from tengu.exceptions import TargetNotAllowedError
-from tengu.security.allowlist import TargetAllowlist
+from tengu.security.allowlist import TargetAllowlist, _suggest_wildcard
 
 
 class TestTargetAllowlist:
@@ -92,3 +92,56 @@ class TestTargetAllowlist:
         assert al.is_allowed("example.com") is True
         assert al.is_allowed("evil.com") is False
         assert al.is_allowed("other.com") is False
+
+    def test_wildcard_hint_when_subdomain_rejected(self):
+        """Rejecting a subdomain of an allowed domain should suggest wildcard."""
+        al = TargetAllowlist(
+            allowed_hosts=["mulesoft.com"],
+            blocked_hosts=[],
+        )
+        with pytest.raises(TargetNotAllowedError, match=r"\*\.mulesoft\.com"):
+            al.check("stgx.anypoint.mulesoft.com")
+
+    def test_no_wildcard_hint_for_unrelated_domain(self):
+        """Unrelated domains should get the standard message, no wildcard hint."""
+        al = TargetAllowlist(
+            allowed_hosts=["mulesoft.com"],
+            blocked_hosts=[],
+        )
+        with pytest.raises(TargetNotAllowedError, match="not in allowed_hosts") as exc_info:
+            al.check("evil.com")
+        assert "*." not in str(exc_info.value)
+
+    def test_exact_match_still_works_with_allowlist(self):
+        """Exact match should pass without needing wildcard."""
+        al = TargetAllowlist(
+            allowed_hosts=["mulesoft.com"],
+            blocked_hosts=[],
+        )
+        al.check("mulesoft.com")  # Should not raise
+
+
+class TestSuggestWildcard:
+    def test_suggests_wildcard_for_subdomain(self):
+        assert _suggest_wildcard("sub.example.com", ["example.com"]) == "*.example.com"
+
+    def test_suggests_wildcard_for_deep_subdomain(self):
+        assert _suggest_wildcard("a.b.c.example.com", ["example.com"]) == "*.example.com"
+
+    def test_no_suggestion_for_exact_match(self):
+        assert _suggest_wildcard("example.com", ["example.com"]) is None
+
+    def test_no_suggestion_for_unrelated_domain(self):
+        assert _suggest_wildcard("evil.com", ["example.com"]) is None
+
+    def test_no_suggestion_for_ip_in_allowlist(self):
+        assert _suggest_wildcard("sub.example.com", ["192.168.1.1"]) is None
+
+    def test_no_suggestion_for_cidr_in_allowlist(self):
+        assert _suggest_wildcard("sub.example.com", ["192.168.1.0/24"]) is None
+
+    def test_skips_existing_wildcards(self):
+        assert _suggest_wildcard("sub.example.com", ["*.example.com"]) is None
+
+    def test_no_suggestion_for_single_label(self):
+        assert _suggest_wildcard("localhost", ["com"]) is None

--- a/tests/unit/test_correlate_dedup.py
+++ b/tests/unit/test_correlate_dedup.py
@@ -1,0 +1,169 @@
+"""Unit tests for finding deduplication and conflict resolution."""
+
+from __future__ import annotations
+
+from tengu.tools.analysis.correlate import (
+    _TOOL_CONFIDENCE,
+    _deduplicate_findings,
+)
+from tengu.tools.analysis.scoring import calculate_risk_score
+
+
+class TestDeduplicateFindings:
+    def test_two_identical_findings_same_endpoint_deduplicated(self):
+        """Two tools reporting the same vuln on the same asset → 1 result."""
+        findings = [
+            {
+                "tool": "nikto",
+                "severity": "high",
+                "affected_asset": "https://example.com/login",
+                "owasp_category": "A03",
+                "title": "XSS in login",
+            },
+            {
+                "tool": "dalfox",
+                "severity": "high",
+                "affected_asset": "https://example.com/login",
+                "owasp_category": "A03",
+                "title": "Reflected XSS",
+            },
+        ]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 1
+        assert len(conflicts) == 1
+        # Dalfox has higher confidence than Nikto → should be kept
+        assert deduped[0]["tool"] == "dalfox"
+
+    def test_nikto_vs_nuclei_conflict_recorded(self):
+        """Nikto 'high' vs Nuclei 'medium' → conflict, higher confidence wins."""
+        findings = [
+            {
+                "tool": "nikto",
+                "severity": "high",
+                "affected_asset": "https://example.com",
+                "owasp_category": "A05",
+            },
+            {
+                "tool": "nuclei",
+                "severity": "medium",
+                "affected_asset": "https://example.com",
+                "owasp_category": "A05",
+            },
+        ]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 1
+        assert len(conflicts) == 1
+        # Nuclei (0.85) > Nikto (0.50)
+        assert deduped[0]["tool"] == "nuclei"
+        assert conflicts[0]["kept"]["tool"] == "nuclei"
+        assert conflicts[0]["duplicates"][0]["tool"] == "nikto"
+
+    def test_no_duplicates_returns_all(self):
+        """Distinct findings should all be returned unchanged."""
+        findings = [
+            {
+                "tool": "nmap",
+                "severity": "info",
+                "affected_asset": "192.168.1.1",
+                "owasp_category": "A06",
+            },
+            {
+                "tool": "nuclei",
+                "severity": "high",
+                "affected_asset": "https://example.com",
+                "owasp_category": "A03",
+            },
+        ]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 2
+        assert len(conflicts) == 0
+
+    def test_cve_id_based_dedup(self):
+        """Findings sharing the same CVE on the same asset should deduplicate."""
+        findings = [
+            {
+                "tool": "nuclei",
+                "severity": "critical",
+                "affected_asset": "https://example.com",
+                "cve_ids": ["CVE-2024-1234"],
+            },
+            {
+                "tool": "nikto",
+                "severity": "high",
+                "affected_asset": "https://example.com",
+                "cve_ids": ["CVE-2024-1234"],
+            },
+        ]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 1
+        assert deduped[0]["tool"] == "nuclei"
+
+    def test_empty_findings(self):
+        deduped, conflicts = _deduplicate_findings([])
+        assert deduped == []
+        assert conflicts == []
+
+    def test_single_finding(self):
+        findings = [{"tool": "nmap", "severity": "info", "affected_asset": "x"}]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 1
+        assert len(conflicts) == 0
+
+    def test_different_assets_not_deduplicated(self):
+        """Same OWASP category but different assets → no dedup."""
+        findings = [
+            {
+                "tool": "nikto",
+                "severity": "high",
+                "affected_asset": "https://a.example.com",
+                "owasp_category": "A03",
+            },
+            {
+                "tool": "nikto",
+                "severity": "high",
+                "affected_asset": "https://b.example.com",
+                "owasp_category": "A03",
+            },
+        ]
+        deduped, conflicts = _deduplicate_findings(findings)
+        assert len(deduped) == 2
+        assert len(conflicts) == 0
+
+
+class TestToolConfidence:
+    def test_known_tools_have_confidence(self):
+        """Verify some key tools are in the confidence map."""
+        assert "sqlmap" in _TOOL_CONFIDENCE
+        assert "nikto" in _TOOL_CONFIDENCE
+        assert "nuclei" in _TOOL_CONFIDENCE
+        assert _TOOL_CONFIDENCE["sqlmap"] > _TOOL_CONFIDENCE["nikto"]
+
+    def test_sqlmap_higher_than_nikto(self):
+        assert _TOOL_CONFIDENCE["sqlmap"] > _TOOL_CONFIDENCE["nikto"]
+
+
+class TestRiskScoreWithToolConfidence:
+    def test_tool_confidence_lowers_nikto_score(self):
+        """Nikto findings should be weighted lower than sqlmap findings."""
+        nikto_findings = [
+            {"tool": "nikto", "severity": "high"},
+            {"tool": "nikto", "severity": "high"},
+        ]
+        sqlmap_findings = [
+            {"tool": "sqlmap", "severity": "high"},
+            {"tool": "sqlmap", "severity": "high"},
+        ]
+        confidence = {"nikto": 0.50, "sqlmap": 0.95}
+
+        nikto_score = calculate_risk_score(nikto_findings, tool_confidence=confidence)
+        sqlmap_score = calculate_risk_score(sqlmap_findings, tool_confidence=confidence)
+        assert sqlmap_score > nikto_score
+
+    def test_without_tool_confidence_identical(self):
+        """Without tool_confidence, same-severity findings score equally."""
+        findings_a = [{"tool": "nikto", "severity": "high"}]
+        findings_b = [{"tool": "sqlmap", "severity": "high"}]
+
+        score_a = calculate_risk_score(findings_a)
+        score_b = calculate_risk_score(findings_b)
+        assert score_a == score_b


### PR DESCRIPTION
## Summary

- **Allowlist wildcard hints**: when a subdomain is rejected, the error now suggests `*.domain.com` if the parent domain is in the allowlist — eliminates the #1 friction point from real bug bounty usage
- **Finding deduplication**: `correlate_findings()` now groups by (asset, OWASP category / CVE ID) and keeps the highest-confidence tool's result, with conflicts tracked separately
- **Focused prompts**: new `bug_bounty_focused` (5-6 tools) and `focused_pentest` (3-5 tools) prompts that reduce context overload vs the 12-20 tool originals
- **Clearer docstrings**: IMPORTANT notes on commonly confused parameter names (`target` vs `url`, `keyword` vs `query`, no `flags` param on nmap)
- **Leaner explore_url**: normal mode reduced from 12 to 8 tools with conditional skip logic

## Test plan

- [x] `ruff check` — 0 errors
- [x] `mypy --strict` — 0 errors  
- [x] 2691 tests passed (48 new: 11 allowlist wildcard, 11 dedup/confidence, 26 existing unchanged)
- [ ] Manual: configure allowlist with `mulesoft.com`, scan `stgx.anypoint.mulesoft.com` → verify wildcard hint in error
- [ ] Manual: `correlate_findings` with duplicate Nikto + Nuclei findings → verify dedup and conflict output

🤖 Generated with [Claude Code](https://claude.com/claude-code)